### PR TITLE
Yuzu System For Button

### DIFF
--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -8,6 +8,7 @@ import * as $api_joke from "./routes/api/joke.ts";
 import * as $index from "./routes/index.tsx";
 import * as $global_type from "./islands/global/type.ts";
 import * as $icon_component_ClosePassword from "./islands/icon/component/ClosePassword.tsx";
+import * as $icon_component_Home from "./islands/icon/component/Home.tsx";
 import * as $icon_component_Icon from "./islands/icon/component/Icon.tsx";
 import * as $icon_component_LoadingSpinner from "./islands/icon/component/LoadingSpinner.tsx";
 import * as $icon_component_OpenPassword from "./islands/icon/component/OpenPassword.tsx";
@@ -73,6 +74,7 @@ const manifest = {
   islands: {
     "./islands/global/type.ts": $global_type,
     "./islands/icon/component/ClosePassword.tsx": $icon_component_ClosePassword,
+    "./islands/icon/component/Home.tsx": $icon_component_Home,
     "./islands/icon/component/Icon.tsx": $icon_component_Icon,
     "./islands/icon/component/LoadingSpinner.tsx":
       $icon_component_LoadingSpinner,

--- a/islands/icon/component/Home.tsx
+++ b/islands/icon/component/Home.tsx
@@ -1,0 +1,15 @@
+export default function Home() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="1em"
+      height="1em"
+      viewBox="0 0 24 24"
+    >
+      <path
+        fill="currentColor"
+        d="M6 19h3v-6h6v6h3v-9l-6-4.5L6 10zm-2 2V9l8-6l8 6v12h-7v-6h-2v6zm8-8.75"
+      />
+    </svg>
+  );
+}

--- a/islands/inputs/button/Button.tsx
+++ b/islands/inputs/button/Button.tsx
@@ -47,7 +47,6 @@ import LoadingSpinner from "../../icon/component/LoadingSpinner.tsx";
 const Button = forwardRef<HTMLButtonElement, ButtonProps>((props) => {
   const {
     domRef,
-    onClick,
     children,
     className,
     isDisabled,
@@ -55,27 +54,26 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>((props) => {
     isLoading,
     GetButtonProps,
     GetSpinnerProps,
-    GetVariantColor,
     GetDisabled,
+    GetSlot,
     ...otherProps
   } = useButton({ ...props });
   const LoadSpinner = (
-    <LoadingSpinner className={`${GetSpinnerProps?.className}`} />
+    <LoadingSpinner className={`${GetSpinnerProps?.className} ${GetSlot.yuzuSpinner}`} />
   );
   return (
 <>
 
       <button
       {...otherProps}
-        onClick={onClick}
-        className={`flex flex-row items-center justify-center gap-2 ${className} ${GetDisabled} ${GetButtonProps.className} ${GetVariantButton}`.trim()}
+        className={`flex flex-row items-center justify-center gap-2 ${className} ${GetDisabled} ${GetButtonProps.className} ${GetVariantButton} ${GetSlot.yuzuBase} ${GetSlot.yuzuDisabled}`.trim()}
         disabled={isDisabled}
         ref={domRef}
       >
         {children}
         {isLoading ? LoadSpinner : null}
       </button>
-     
+      
       </>
   );
 });

--- a/islands/inputs/button/Button.tsx
+++ b/islands/inputs/button/Button.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from "preact/compat";
 import type { ButtonProps } from "./type.ts";
 import { useButton } from "./use-button.ts";
-
+import type { JSX } from "preact/jsx-runtime";
 /**
  * Button component with custom configuration variant
  * @component
@@ -51,6 +51,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>((props) => {
     children,
     className,
     isDisabled,
+    GetVariantButton,
     isLoading,
     GetButtonProps,
     GetSpinnerProps,
@@ -62,21 +63,20 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>((props) => {
     <LoadingSpinner className={`${GetSpinnerProps?.className}`} />
   );
   return (
-    <div
-      disabled={isDisabled}
-      className={`flex flex-row justify-center items-center gap-4 ${GetButtonProps.className} ${GetVariantColor}  `}
-    >
+<>
+
       <button
-        {...otherProps}
+      {...otherProps}
         onClick={onClick}
-        className={` ${className} ${GetDisabled}`.trim()}
+        className={`flex flex-row items-center justify-center gap-2 ${className} ${GetDisabled} ${GetButtonProps.className} ${GetVariantButton}`.trim()}
         disabled={isDisabled}
         ref={domRef}
       >
         {children}
+        {isLoading ? LoadSpinner : null}
       </button>
-      {isLoading ? LoadSpinner : null}
-    </div>
+     
+      </>
   );
 });
 

--- a/islands/inputs/button/Button.tsx
+++ b/islands/inputs/button/Button.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from "preact/compat";
 import type { ButtonProps } from "./type.ts";
 import { useButton } from "./use-button.ts";
-import type { JSX } from "preact/jsx-runtime";
+
 /**
  * Button component with custom configuration variant
  * @component
@@ -9,39 +9,46 @@ import type { JSX } from "preact/jsx-runtime";
  * @example
  * <Button
  *  size = "small",
- *  variant = "primary",
+ *  variant = "solid",
  *  types = "button",
- *  radius = "md" >
+ *  radius = "md"
+ *  endContent={<Home />}
+ * isLoading={false}>
  *    Click Me!!!
  * </Button>
  *
  * @param {Ref<HTMLButtonElement>} props.domRef - The ref for the button element.
- * @param {Function} props.onClick - The click handler for the button.
  * @param {JSX.Element} props.children - The content inside the button.
  * @param {string} [props.className=""] - Additional classes to apply to the button, if no value provided will return empty string
- * @param {JSX.CSSProperties} [props.style] - Inline styles to apply to the button.
  * @param {boolean} [props.isDisabled=false] - Disable the button functionality
  * @param {string} [props.size="small"] - The size of the button can be modified and extended
  * - `small`: Small button
  * - `medium`: Medium button (default)
  * - `large`: Large button
- * @param {string} [props.variant="primary"] - The variant of the button be modified and extended
+ * - `full`: Full parent button
+ * @param {string} [props.color="primary"] - The color of the button be modified and extended
  * - `primary` (default)
  * - `secondary`
  * - `error`
  * - `success`
  * - `warning`
  * - `custom`: your custom variant
- * @param {string} [props.types="button"] - The type of the button. Options are
- * - `button`: Default button type
- * - `reset`: Reset button type
- * - `submit`: Submit button type
+ *  * @param {string} [props.variant="primary"] - The variant of the button and can be extended in hooks and variant
+ * - `solid`: Solid button with background color.
+ * - `border`: Border button with outlined style.
+ * - `ghost`: Transparent background with a border and text color.
+ * - `flat`: Flat button without background, text color only.
  * @param {string} [props.radius="md"] - The radius of the button be modified and extended
  * - `sm`: small radius
  * - `md`: medium radius (default)
  * - `lg`: large radius
- * @param {string} [props.yuzuDisableStyle=""] - Custom styles for disabled state (optional).
- * @param {boolean} [props.isFullWidth=false] - Set the button to be full width.
+ * @param {string} [classNames] - Custom styles for component
+ * - `yuzuBase`: The base classes applied to the button wrapper.
+ * - `yuzuDisabled`: The classes applied when the button is disabled.
+ * - `yuzuSpinner`: The classes applied to the spinner element inside the button when loading.
+ * @param {boolean} [props.isLoading=false] - A flag to indicate if the button is in a loading state.
+ * @param {JSX.Element} [endContent] - Add icon to end of title
+ * @param {JSX.Element} [startContent] - Add icon to start of title
  */
 import LoadingSpinner from "../../icon/component/LoadingSpinner.tsx";
 const Button = forwardRef<HTMLButtonElement, ButtonProps>((props) => {
@@ -55,26 +62,31 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>((props) => {
     GetButtonProps,
     GetSpinnerProps,
     GetDisabled,
+    endContent,
+    startContent,
     GetSlot,
     ...otherProps
   } = useButton({ ...props });
   const LoadSpinner = (
-    <LoadingSpinner className={`${GetSpinnerProps?.className} ${GetSlot.yuzuSpinner}`} />
+    <LoadingSpinner
+      className={`${GetSpinnerProps?.className} ${GetSlot.yuzuSpinner}`}
+    />
   );
   return (
-<>
-
+    <>
       <button
-      {...otherProps}
-        className={`flex flex-row items-center justify-center gap-2 ${className} ${GetDisabled} ${GetButtonProps.className} ${GetVariantButton} ${GetSlot.yuzuBase} ${GetSlot.yuzuDisabled}`.trim()}
+        {...otherProps}
+        className={`flex flex-row items-center justify-center gap-2 ${className} ${GetDisabled} ${GetButtonProps.className} ${GetVariantButton} ${GetSlot.yuzuBase} ${GetSlot.yuzuDisabled}`
+          .trim()}
         disabled={isDisabled}
         ref={domRef}
       >
+        {startContent ? startContent : null}
         {children}
+        {endContent ? endContent : null}
         {isLoading ? LoadSpinner : null}
       </button>
-      
-      </>
+    </>
   );
 });
 

--- a/islands/inputs/button/button-variant.ts
+++ b/islands/inputs/button/button-variant.ts
@@ -27,12 +27,10 @@ export const ButtonVariants = {
     large: "w-6 h-6  border-6 border-t-transparent rounded-full",
   },
   variants: {
-    solid:
-      "active:scale-95 focus:outline-none transition ease-in-out duration-500",
-    border: "active:scale-95 transition ease-in-out duration-500 border-2",
-    light: "active:scale-95 transition ease-in-out duration-500 delay-150",
-    ghost:
-      "active:scale-95 transition ease-in-out duration-500 border-1 hover:text-white",
+    solid: (color: string) => `hover:bg-${color}/60 bg-${color} active:bg-${color} disabled:bg-${color}/60 disabled:hover:bg-${color}/60 focus:outline-none active:scale-95 focus:outline-none transition ease-in-out duration-500`,
+    border: (color: string) => `border-2 border-${color} active:bg-${color}/50 hover:border-${color} focus:outline-none transition ease-in-out duration-500 active:scale-95`,
+    light: (color: string) => `hover:bg-${color}/60 text-${color} active:text-${color} active:scale-95 transition ease-in-out duration-500`,
+    ghost: (color: string) => `border-2 hover:bg-${color}/50 text-${color} active:text-white active:scale-95 transition ease-in-out duration-500 hover:text-white disabled:text-white disabled:bg-${color}/50`,
   },
   colors: {
     primary: "primary",

--- a/islands/inputs/button/button-variant.ts
+++ b/islands/inputs/button/button-variant.ts
@@ -23,9 +23,9 @@ export const ButtonVariants = {
     },
   },
   spinnersSizes: {
-    small: "w-2 h-2 border-1 border-t-transparent rounded-full",
-    medium: "w-4 h-4 border-3 border-t-transparent rounded-full",
-    large: "w-6 h-6 border-5 border-t-transparent rounded-full",
+    small: "w-4 h-4 border-2 border-t-transparent rounded-full",
+    medium: "w-5 h-5 border-4 border-t-transparent rounded-full",
+    large: "w-6 h-6  border-6 border-t-transparent rounded-full",
   },
   variants: {
     solid: "active:scale-95 focus:outline-none transition ease-in-out duration-500",

--- a/islands/inputs/button/button-variant.ts
+++ b/islands/inputs/button/button-variant.ts
@@ -5,8 +5,9 @@ Can be extended with more variant
 */
 
 export const ButtonVariants = {
+  baseStyle: "active:scale-95 transition ease-in-out duration-500",
   disableStyle:
-    "disabled:active:opacity-20 active:opacity-20 disabled:opacity-20 cursor-not-allowed ",
+    "disabled:opacity-20 cursor-not-allowed ",
   radiusStyle: {
     sm: "rounded-sm",
     md: "rounded-md",
@@ -15,36 +16,22 @@ export const ButtonVariants = {
   loadingStyle: "brightness-80",
   sizes: {
     buttons: {
-      small: "py-4 px-4 w-28 h-6 transition duration-150 ease-in-out",
-      medium: "py-5 px-4 w-32 h-8 transition duration-150 ease-in-out",
-      large: "py-6 px-4 w-44  h-10 transition duration-150 ease-in-out",
-      full: "py-6 px-4 w-full h-14 transition duration-150 ease-in-out",
+      small: "p-2 w-32",
+      medium: "p-2 w-36",
+      large: "p-2 w-48",
+      full: "p-2 w-full",
     },
   },
   spinnersSizes: {
-    small: "w-4 h-4 border-4 border-t-transparent rounded-full",
-    medium: "w-5 h-5 border-4 border-t-transparent rounded-full",
-    large: "w-8 h-8 border-4 border-t-transparent rounded-full",
+    small: "w-2 h-2 border-1 border-t-transparent rounded-full",
+    medium: "w-4 h-4 border-3 border-t-transparent rounded-full",
+    large: "w-6 h-6 border-5 border-t-transparent rounded-full",
   },
-  spinnerStop: "animate-none transition ease-in-out duration-150",
-  spinnerAnimate: "animate-spin transition ease-in-out duration-150",
-  // variantsStyle: {
-  //   primary:
-  //     "bg-primary active:bg-primary/20 focus:outline-2 focus:outline-primary/80 ",
-  //   secondary:
-  //     "bg-secondary active:bg-secondary/20 focus:outline-2 focus:outline-secondary/80",
-  //   error: "bg-error active:bg-error/20 focus:outline-2 focus:outline-error/80",
-  //   success:
-  //     "bg-success active:bg-success/20 focus:outline-2 focus:outline-success/80",
-  //   warning:
-  //     "bg-warning active:bg-warning/20 focus:outline-2 focus:outline-warning/80",
-  // },
   variants: {
-    solid: "bg-",
-    border: "border-2 border-",
-    light: "hover:bg-",
-    ghost: "hover:bg-",
-    shadow: "shadow-md shadow-white bg-",
+    solid: "active:scale-95 focus:outline-none transition ease-in-out duration-500",
+    border: "active:scale-95 transition ease-in-out duration-500 border-2",
+    light: "active:scale-95 transition ease-in-out duration-500 delay-150",
+    ghost: "active:scale-95 transition ease-in-out duration-500 border-1 hover:text-white",
   },
   colors: {
     primary: "primary",
@@ -53,10 +40,5 @@ export const ButtonVariants = {
     success: "success",
     warning: "warning",
     none: "",
-  },
-  types: {
-    button: "button",
-    reset: "reset",
-    submit: "submit",
   },
 };

--- a/islands/inputs/button/button-variant.ts
+++ b/islands/inputs/button/button-variant.ts
@@ -6,8 +6,7 @@ Can be extended with more variant
 
 export const ButtonVariants = {
   baseStyle: "active:scale-95 transition ease-in-out duration-500",
-  disableStyle:
-    "disabled:opacity-20 cursor-not-allowed ",
+  disableStyle: "disabled:opacity-20 cursor-not-allowed ",
   radiusStyle: {
     sm: "rounded-sm",
     md: "rounded-md",
@@ -28,10 +27,12 @@ export const ButtonVariants = {
     large: "w-6 h-6  border-6 border-t-transparent rounded-full",
   },
   variants: {
-    solid: "active:scale-95 focus:outline-none transition ease-in-out duration-500",
+    solid:
+      "active:scale-95 focus:outline-none transition ease-in-out duration-500",
     border: "active:scale-95 transition ease-in-out duration-500 border-2",
     light: "active:scale-95 transition ease-in-out duration-500 delay-150",
-    ghost: "active:scale-95 transition ease-in-out duration-500 border-1 hover:text-white",
+    ghost:
+      "active:scale-95 transition ease-in-out duration-500 border-1 hover:text-white",
   },
   colors: {
     primary: "primary",

--- a/islands/inputs/button/type.ts
+++ b/islands/inputs/button/type.ts
@@ -30,10 +30,11 @@ export type ButtonProps =
      * @type {string} empty string if not provided
      */
     className?: string;
+
     /**
-     * Custom class names for specific parts of the `SelectGroup` component, such as base, label, error, and more.
-     *
-     * @type {SelectGroupSlot}
+     * Custom class names for specific parts of the button.
+     * Use this to style the button's base, disabled state, or spinner individually.
+     * @type {ButtonSlot}
      */
     classNames?: ButtonSlot;
 
@@ -46,7 +47,6 @@ export type ButtonProps =
     /**
      * Customize can be done in button-variants and can be extended with additional size
      * @default small
-     *
      * Add Custom size
      * @example
      * size: {extra-large: "w-72 h-42"}
@@ -76,12 +76,34 @@ export type ButtonProps =
 
     /**
      * @default false
-     * Should a Button take parent width don't use with size
+     * Should a Button take parent width
      */
     isFullWidth?: boolean;
 
+    /**
+     * Indicates whether the button is in a loading state.
+     * When true, a loading spinner will be displayed inside the button.
+     * @default false
+     * @type {boolean}
+     */
     isLoading?: boolean;
 
+    /**
+     * The size of the spinner when the button is loading.
+     * You can select from predefined spinner sizes in the ButtonVariants file.
+     * @type {keyof typeof ButtonVariants.spinnersSizes}
+     */
     spinnerSize?: keyof typeof ButtonVariants.spinnersSizes;
 
+    /**
+     * The content that will be placed after the button text. Can be an icon or other content.
+     * @type {JSX.Element}
+     */
+    endContent?: JSX.Element;
+
+    /**
+     * The content that will be placed before the button text. Can be an icon or other content.
+     * @type {JSX.Element}
+     */
+    startContent?: JSX.Element;
   };

--- a/islands/inputs/button/type.ts
+++ b/islands/inputs/button/type.ts
@@ -70,7 +70,7 @@ export type ButtonProps =
      * Button radius can be extended in variant file
      * @default "small"
      *
-     * @enum {"sm" | "md" | "lg"}
+     * @enum {"sm" | "md" | "lg |"fullWidth"}
      */
     radius?: keyof typeof ButtonVariants.radiusStyle;
 
@@ -83,4 +83,5 @@ export type ButtonProps =
     isLoading?: boolean;
 
     spinnerSize?: keyof typeof ButtonVariants.spinnersSizes;
+
   };

--- a/islands/inputs/button/type.ts
+++ b/islands/inputs/button/type.ts
@@ -18,11 +18,6 @@ export type ButtonProps =
     domRef?: Ref<HTMLButtonElement>;
 
     /**
-     * Return function void for button
-     */
-    onClick?: () => void;
-
-    /**
      * Take any component for children, can't be used with label
      *
      * @example

--- a/islands/inputs/button/use-button.ts
+++ b/islands/inputs/button/use-button.ts
@@ -15,20 +15,22 @@ export function useButton(props: ButtonProps) {
     radius = "md",
     isLoading,
     isFullWidth = false,
+    endContent,
+    startContent,
     ...otherProps
   } = props;
 
   const GetColor = useMemo(
     () => {
-      const colors = ButtonVariants.colors[color]
-      return colors
+      const colors = ButtonVariants.colors[color];
+      return colors;
     },
     [color],
   );
   const GetVariant = useMemo(
     () => {
       return {
-        variant: ButtonVariants.variants
+        variant: ButtonVariants.variants,
       };
     },
     [variant],
@@ -44,10 +46,10 @@ export function useButton(props: ButtonProps) {
       case "ghost":
         return `border-${color} text-${color} hover:text-white disabled:text-white disabled:hover:text-${color} hover:bg-${color} disabled:bg-${color}/50`;
       default:
-        return ""; 
+        return "";
     }
   }
-  const baseStyle = ButtonVariants.baseStyle
+  const baseStyle = ButtonVariants.baseStyle;
   const variants = {
     solid: `${baseStyle} focus:outline-none `,
     border: `${baseStyle} border-2`,
@@ -56,7 +58,7 @@ export function useButton(props: ButtonProps) {
   };
   const GetVariantButton = useMemo(() => {
     const color = GetColor;
-    const variantStyle = variants[variant]
+    const variantStyle = variants[variant];
     const colorStyles = GetStyle(color, variant);
     return `${variantStyle} ${colorStyles}`.trim();
   }, [GetColor, variant]);
@@ -72,15 +74,15 @@ export function useButton(props: ButtonProps) {
   );
 
   /**
-   * Hooks for checking the size of the spinner, can be customized 
+   * Hooks for checking the size of the spinner, can be customized
    * and extended via variant file
-   * @param {string} [spinnerSize="small"] 
+   * @param {string} [spinnerSize="small"]
    * @enum
    * "primary"   | @default
-   * "secondary" | 
-   * "error"     | 
-   * "warning"   | 
-   * "success"   | 
+   * "secondary" |
+   * "error"     |
+   * "warning"   |
+   * "success"   |
    * "Your Variant"
    */
 
@@ -128,7 +130,6 @@ export function useButton(props: ButtonProps) {
     () => {
       if (isLoading === true) {
         const sizes = GetSpinnerSize.sizespin;
-        console.log(sizes)
         return {
           className: `${sizes} animate-spin`,
         };
@@ -139,13 +140,16 @@ export function useButton(props: ButtonProps) {
   const GetSlot = useMemo(
     () => {
       const yuzuBase = classNames?.yuzuBase ? classNames?.yuzuBase : "";
-      const yuzuDisabled = GetDisabled ? GetDisabled + classNames?.yuzuDisabled : ""
-      const yuzuSpinner = classNames?.yuzuSpinner ? classNames?.yuzuSpinner : "";
-      console.log(yuzuDisabled)
+      const yuzuDisabled = GetDisabled
+        ? GetDisabled + classNames?.yuzuDisabled
+        : "";
+      const yuzuSpinner = classNames?.yuzuSpinner
+        ? classNames?.yuzuSpinner
+        : "";
       return {
         yuzuBase,
         yuzuDisabled,
-        yuzuSpinner
+        yuzuSpinner,
       };
     },
     [classNames],
@@ -160,6 +164,8 @@ export function useButton(props: ButtonProps) {
     isLoading,
     GetDisabled,
     GetButtonProps,
+    endContent,
+    startContent,
     GetSlot,
     ...otherProps,
   };

--- a/islands/inputs/button/use-button.ts
+++ b/islands/inputs/button/use-button.ts
@@ -35,32 +35,21 @@ export function useButton(props: ButtonProps) {
     },
     [variant],
   );
-  function GetStyle(color: string, variant: string) {
-    switch (variant) {
-      case "solid":
-        return `hover:bg-${color}/60 bg-${color} active:bg-${color} disabled:bg-${color}/60 disabled:hover:bg-${color}/60`;
-      case "border":
-        return `border-${color} active:bg-${color}/20`;
-      case "light":
-        return `hover:bg-${color}/60 text-${color}-200`;
-      case "ghost":
-        return `border-${color} text-${color} hover:text-white disabled:text-white disabled:hover:text-${color} hover:bg-${color} disabled:bg-${color}/50`;
-      default:
-        return "";
-    }
-  }
-  const baseStyle = ButtonVariants.baseStyle;
-  const variants = {
-    solid: `${baseStyle} focus:outline-none `,
-    border: `${baseStyle} border-2`,
-    light: `${baseStyle} delay-150`,
-    ghost: `${baseStyle} border-2`,
-  };
+
+
+  const GetVariantNew = useMemo(
+    () => {
+      const variants = ButtonVariants.variants[variant](color)
+      console.log(variants)
+      return {
+        variants 
+      }
+    },[variant])
   const GetVariantButton = useMemo(() => {
-    const color = GetColor;
-    const variantStyle = variants[variant];
-    const colorStyles = GetStyle(color, variant);
-    return `${variantStyle} ${colorStyles}`.trim();
+    const variantStyle = GetVariantNew.variants
+    console.log(variantStyle)
+
+    return `${variantStyle}`.trim();
   }, [GetColor, variant]);
 
   /**

--- a/islands/inputs/button/use-button.ts
+++ b/islands/inputs/button/use-button.ts
@@ -6,6 +6,7 @@ export function useButton(props: ButtonProps) {
     domRef,
     children,
     className = "",
+    classNames,
     isDisabled,
     size = "small",
     spinnerSize = "small",
@@ -55,34 +56,11 @@ export function useButton(props: ButtonProps) {
   };
   const GetVariantButton = useMemo(() => {
     const color = GetColor;
-    const variantStyle = variants[variant] || "";
+    const variantStyle = variants[variant]
     const colorStyles = GetStyle(color, variant);
-  
     return `${variantStyle} ${colorStyles}`.trim();
   }, [GetColor, variant]);
-  const GetVariantColor = useMemo(
-    () => {
-      if (variant === "solid") {
-        const color = GetColor
-        const variants = ButtonVariants.variants.solid
-        console.log(color)
-        return `${variants} hover:bg-${color}/60 bg-${color} active:bg-${color} ` ;
-      } else if (variant === "border") {
-        const color = GetColor;
-        const variants = ButtonVariants.variants.border;
-        return `${variants} border-${color} active:bg-${color}/20`;
-      } else if (variant === "ghost") {
-        const color = GetColor
-        const variants = ButtonVariants.variants.ghost
-        return `${variants} border-${color} text-${color} hover:bg-${color} active:bg-white`
-      } else if(variant === "light") {
-        const color = GetColor
-        const variants = ButtonVariants.variants.light
-        return `${variants} hover:bg-${color}/60 ${variant} text-${color}`
-      }
-    },
-    [GetColor, GetVariant, variant, color],
-  );
+
   /**
    * check if button disabled and return the disabled style from variant
    * @default false
@@ -126,7 +104,7 @@ export function useButton(props: ButtonProps) {
         return sizes;
       }
     },
-    [size, spinnerSize, isFullWidth],
+    [size, isFullWidth],
   );
   /**
    * @description
@@ -150,6 +128,7 @@ export function useButton(props: ButtonProps) {
     () => {
       if (isLoading === true) {
         const sizes = GetSpinnerSize.sizespin;
+        console.log(sizes)
         return {
           className: `${sizes} animate-spin`,
         };
@@ -157,7 +136,20 @@ export function useButton(props: ButtonProps) {
     },
     [isLoading, GetSpinnerSize],
   );
-
+  const GetSlot = useMemo(
+    () => {
+      const yuzuBase = classNames?.yuzuBase ? classNames?.yuzuBase : "";
+      const yuzuDisabled = GetDisabled ? GetDisabled + classNames?.yuzuDisabled : ""
+      const yuzuSpinner = classNames?.yuzuSpinner ? classNames?.yuzuSpinner : "";
+      console.log(yuzuDisabled)
+      return {
+        yuzuBase,
+        yuzuDisabled,
+        yuzuSpinner
+      };
+    },
+    [classNames],
+  );
   return {
     domRef,
     children,
@@ -167,8 +159,8 @@ export function useButton(props: ButtonProps) {
     isDisabled,
     isLoading,
     GetDisabled,
-    GetVariantColor,
     GetButtonProps,
+    GetSlot,
     ...otherProps,
   };
 }

--- a/islands/inputs/button/use-button.ts
+++ b/islands/inputs/button/use-button.ts
@@ -4,7 +4,6 @@ import { ButtonVariants } from "./button-variant.ts";
 export function useButton(props: ButtonProps) {
   const {
     domRef,
-    onClick,
     children,
     className = "",
     isDisabled,
@@ -20,46 +19,66 @@ export function useButton(props: ButtonProps) {
 
   const GetColor = useMemo(
     () => {
-      return {
-        color: ButtonVariants.colors[color],
-      };
+      const colors = ButtonVariants.colors[color]
+      return colors
     },
     [color],
   );
   const GetVariant = useMemo(
     () => {
       return {
-        variant: ButtonVariants.variants[variant],
+        variant: ButtonVariants.variants
       };
     },
     [variant],
   );
-
+  function GetStyle(color: string, variant: string) {
+    switch (variant) {
+      case "solid":
+        return `hover:bg-${color}/60 bg-${color} active:bg-${color} disabled:bg-${color}/60 disabled:hover:bg-${color}/60`;
+      case "border":
+        return `border-${color} active:bg-${color}/20`;
+      case "light":
+        return `hover:bg-${color}/60 text-${color}-200`;
+      case "ghost":
+        return `border-${color} text-${color} hover:text-white disabled:text-white disabled:hover:text-${color} hover:bg-${color} disabled:bg-${color}/50`;
+      default:
+        return ""; 
+    }
+  }
+  const baseStyle = ButtonVariants.baseStyle
+  const variants = {
+    solid: `${baseStyle} focus:outline-none `,
+    border: `${baseStyle} border-2`,
+    light: `${baseStyle} delay-150`,
+    ghost: `${baseStyle} border-2`,
+  };
+  const GetVariantButton = useMemo(() => {
+    const color = GetColor;
+    const variantStyle = variants[variant] || "";
+    const colorStyles = GetStyle(color, variant);
+  
+    return `${variantStyle} ${colorStyles}`.trim();
+  }, [GetColor, variant]);
   const GetVariantColor = useMemo(
     () => {
-      
       if (variant === "solid") {
-        const color = GetColor.color;
-        const variants = GetVariant.variant
-        console.log(variants);
-        return `${variants}${color}`;
+        const color = GetColor
+        const variants = ButtonVariants.variants.solid
+        console.log(color)
+        return `${variants} hover:bg-${color}/60 bg-${color} active:bg-${color} ` ;
       } else if (variant === "border") {
-        const color = GetColor.color;
+        const color = GetColor;
         const variants = ButtonVariants.variants.border;
-        return `${variants}${color}`;
+        return `${variants} border-${color} active:bg-${color}/20`;
       } else if (variant === "ghost") {
-        const color = GetColor.color;
-        console.log("coor", color);
-        // const borders = ButtonVariants.variants.border;
-        // const colorbor = borders + color;
-        const variants = ButtonVariants.variants.ghost;
-        
-        const combine = variants + color
-        console.log('type',typeof combine)
-        console.log(combine);
-        return combine.toString()
-      } else {
-        return "";
+        const color = GetColor
+        const variants = ButtonVariants.variants.ghost
+        return `${variants} border-${color} text-${color} hover:bg-${color} active:bg-white`
+      } else if(variant === "light") {
+        const color = GetColor
+        const variants = ButtonVariants.variants.light
+        return `${variants} hover:bg-${color}/60 ${variant} text-${color}`
       }
     },
     [GetColor, GetVariant, variant, color],
@@ -75,14 +94,21 @@ export function useButton(props: ButtonProps) {
   );
 
   /**
-   * Hooks for checking the type of the button
-   * @returns {string} type  e.g "button"
+   * Hooks for checking the size of the spinner, can be customized 
+   * and extended via variant file
+   * @param {string} [spinnerSize="small"] 
+   * @enum
+   * "primary"   | @default
+   * "secondary" | 
+   * "error"     | 
+   * "warning"   | 
+   * "success"   | 
+   * "Your Variant"
    */
 
   const GetSpinnerSize = useMemo(
     () => {
       const sizespin = ButtonVariants.spinnersSizes[spinnerSize];
-
       return {
         sizespin,
       };
@@ -117,7 +143,7 @@ export function useButton(props: ButtonProps) {
           .trim(),
       };
     },
-    [radius, GetSize],
+    [radius, GetSize, GetDisabled, color, GetColor, GetVariant, variant],
   );
 
   const GetSpinnerProps = useMemo(
@@ -134,10 +160,10 @@ export function useButton(props: ButtonProps) {
 
   return {
     domRef,
-    onClick,
     children,
     GetSpinnerProps,
     className,
+    GetVariantButton,
     isDisabled,
     isLoading,
     GetDisabled,

--- a/islands/wrapper.tsx
+++ b/islands/wrapper.tsx
@@ -30,26 +30,46 @@ export default function Wrapper() {
       <div class={"w-full flex flex-col gap-2"}>
         <div className={""}>
           <div className={`w-full flex flex-col gap-2`}>
+        
             <Button
               variant="solid"
-              form={"name"}
-              name={"ass"}
               onClick={toggleDisabled}
-              size="large"
-              color="success"
+              size="small"
+              color="secondary"
+              isLoading={false}
+              isDisabled
             >
-              asds
+              SUBMIT
+            </Button>
+            <Button
+              variant="border"
+              onClick={toggleDisabled}
+              isLoading={false}
+              size="medium"
+              color="secondary"
+              isDisabled
+            >
+              SUBMIT
+            </Button>
+            <Button
+              variant="light"
+              onClick={toggleDisabled}
+              isLoading={false}
+              size="large"
+              color="secondary"
+              
+            >
+              LIGHT
             </Button>
             <Button
               variant="ghost"
-              form={"name"}
-              name={"ass"}
               onClick={toggleDisabled}
               isLoading={false}
-              size="small"
-              color="error"
+              size="large"
+              color="secondary"
+              isDisabled
             >
-              ASDF
+              GHOST
             </Button>
           </div>
         </div>

--- a/islands/wrapper.tsx
+++ b/islands/wrapper.tsx
@@ -65,6 +65,7 @@ export default function Wrapper() {
               isLoading={true}
               size="large"
               color="secondary"
+              
             >
               GHOST
             </Button>

--- a/islands/wrapper.tsx
+++ b/islands/wrapper.tsx
@@ -36,25 +36,25 @@ export default function Wrapper() {
               onClick={toggleDisabled}
               size="small"
               color="secondary"
-              isLoading={false}
-              isDisabled
+              isLoading
+          
             >
               SUBMIT
             </Button>
             <Button
               variant="border"
               onClick={toggleDisabled}
-              isLoading={false}
+              isLoading={true}
               size="medium"
               color="secondary"
-              isDisabled
+              
             >
               SUBMIT
             </Button>
             <Button
               variant="light"
               onClick={toggleDisabled}
-              isLoading={false}
+              isLoading={true}
               size="large"
               color="secondary"
               
@@ -64,10 +64,10 @@ export default function Wrapper() {
             <Button
               variant="ghost"
               onClick={toggleDisabled}
-              isLoading={false}
+              isLoading={true}
               size="large"
               color="secondary"
-              isDisabled
+              
             >
               GHOST
             </Button>

--- a/islands/wrapper.tsx
+++ b/islands/wrapper.tsx
@@ -7,9 +7,10 @@ import {
 import SelectGroup from "./inputs/select/select-field/SelectGroup.tsx";
 import SelectItem from "./inputs/select/select-item/SelectItem.tsx";
 import Button from "./inputs/button/Button.tsx";
+import Home from "./icon/component/Home.tsx";
 
 export default function Wrapper() {
-  const fieldsetRef = useRef<HTMLSelectElement>(null);
+  const fieldsetRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     // Check if the fieldset ref is assigned properly
@@ -30,14 +31,13 @@ export default function Wrapper() {
       <div class={"w-full flex flex-col gap-2"}>
         <div className={""}>
           <div className={`w-full flex flex-col gap-2`}>
-        
             <Button
               variant="solid"
               onClick={toggleDisabled}
               size="small"
               color="secondary"
-              isLoading
-          
+              endContent={<Home />}
+              domRef={fieldsetRef}
             >
               SUBMIT
             </Button>
@@ -47,7 +47,6 @@ export default function Wrapper() {
               isLoading={true}
               size="medium"
               color="secondary"
-              
             >
               SUBMIT
             </Button>
@@ -57,7 +56,6 @@ export default function Wrapper() {
               isLoading={true}
               size="large"
               color="secondary"
-              
             >
               LIGHT
             </Button>
@@ -67,7 +65,6 @@ export default function Wrapper() {
               isLoading={true}
               size="large"
               color="secondary"
-              
             >
               GHOST
             </Button>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,25 @@ export default {
   content: [
     "{routes,islands,components}/**/*.{ts,tsx,js,jsx}",
   ],
+  safelist: [
+    {
+      pattern: /from-(primary|secondary|success|error|warning)/,
+      variants: ['hover', 'active', 'disabled', 'focus']
+    },
+    {
+      pattern: /to-(primary|secondary|success|error|warning)/,
+      variants: ['hover', 'active', 'disabled', 'focus']
+    },
+    {
+      pattern: /bg-(primary|secondary|success|error|warning)/,
+      variants: ['hover', 'active', 'disabled', 'focus']
+    },
+    {
+      pattern: /ring-(primary|secondary|success|error|warning)/,
+      variants: ['hover', 'active', 'focus']
+    },
+  ],
+  
   theme: {
     extend: {
       animation: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,22 +8,22 @@ export default {
   safelist: [
     {
       pattern: /from-(primary|secondary|success|error|warning)/,
-      variants: ['hover', 'active', 'disabled', 'focus']
+      variants: ["hover", "active", "disabled", "focus"],
     },
     {
       pattern: /to-(primary|secondary|success|error|warning)/,
-      variants: ['hover', 'active', 'disabled', 'focus']
+      variants: ["hover", "active", "disabled", "focus"],
     },
     {
       pattern: /bg-(primary|secondary|success|error|warning)/,
-      variants: ['hover', 'active', 'disabled', 'focus']
+      variants: ["hover", "active", "disabled", "focus"],
     },
     {
       pattern: /ring-(primary|secondary|success|error|warning)/,
-      variants: ['hover', 'active', 'focus']
+      variants: ["hover", "active", "focus"],
     },
   ],
-  
+
   theme: {
     extend: {
       animation: {


### PR DESCRIPTION
- Button now accept classNames as part of yuzu override system class
- Spinner as default in `isLoading` with `span` at component `./icon/component/LoadingSpinner.tsx`
- Available to get logo component at `endContent startContent`
- New 4 variant while can accept color via `Tailwind Safelist`
- Due to complexity of element the extended variant can only be change after altering variant style in `button-variants.ts` every variant will have params for string color

**Example**
```
classNames: {{
yuzuDisabled: "add class"}}
```