### PR TITLE
Yuzu Sytem Label & Fieldset

### DIFF
--- a/islands/inputs/checkbox/Checkbox.tsx
+++ b/islands/inputs/checkbox/Checkbox.tsx
@@ -73,9 +73,13 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props) => {
     GetCheckboxProps,
     GetWrapperStyle,
     label,
+    CheckRender,
     GetSlot,
     ...otherProps
   } = useCheckbox({ ...props });
+  if (CheckRender instanceof Error) {
+    throw CheckRender; 
+  }
   const InputWrapper = (
     <input
       {...otherProps}
@@ -100,12 +104,12 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props) => {
       return (
         <div
           disabled={GetCheckboxProps.isDisabled}
-          className={`${GetWrapperStyle.className} ${GetSlot.yuzuBase} ${GetSlot.yuzuBaseDisabled} flex flex-col gap-2 items-center
+          className={`flex flex-row gap-2 items-center ${GetWrapperStyle.className} ${GetSlot.yuzuBase} ${GetSlot.yuzuBaseDisabled} 
    `.trim()}
         >
-          {children}
+          
           {InputWrapper}
-          {LabelWrapper}
+          {children || LabelWrapper}
         </div>
       );
     }
@@ -115,11 +119,10 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props) => {
       return (
         <div
           disabled={GetCheckboxProps.isDisabled}
-          className={`${GetWrapperStyle.className} ${GetSlot.yuzuBase} ${GetSlot.yuzuBaseDisabled} flex flex-col gap-2 items-center
+          className={`flex flex-row gap-2 items-center ${GetWrapperStyle.className} ${GetSlot.yuzuBase} ${GetSlot.yuzuBaseDisabled} x
    `.trim()}
         >
-          {children}
-          {LabelWrapper}
+          {children || LabelWrapper}
           {InputWrapper}
         </div>
       );
@@ -130,11 +133,10 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props) => {
       return (
         <div
           disabled={GetCheckboxProps.isDisabled}
-          className={`${GetWrapperStyle.className} ${GetSlot.yuzuBase} ${GetSlot.yuzuBaseDisabled} flex flex-col gap-2 items-center
+          className={`flex flex-col gap-2 items-center ${GetWrapperStyle.className} ${GetSlot.yuzuBase} ${GetSlot.yuzuBaseDisabled} 
    `.trim()}
         >
-          {children}
-          {LabelWrapper}
+          {children || LabelWrapper}
           {InputWrapper}
         </div>
       );
@@ -145,12 +147,11 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props) => {
       return (
         <div
           disabled={GetCheckboxProps.isDisabled}
-          className={`${GetWrapperStyle.className} ${GetSlot.yuzuBase} ${GetSlot.yuzuBaseDisabled} flex flex-col gap-2 items-center
+          className={`flex flex-col gap-2 items-center ${GetWrapperStyle.className} ${GetSlot.yuzuBase} ${GetSlot.yuzuBaseDisabled} 
    `.trim()}
         >
-          {children}
           {InputWrapper}
-          {LabelWrapper}
+          {children || LabelWrapper}
         </div>
       );
     }

--- a/islands/inputs/checkbox/use-checkbox.ts
+++ b/islands/inputs/checkbox/use-checkbox.ts
@@ -148,6 +148,20 @@ export function useCheckbox(props: CheckboxProps) {
     },
     [classNames, GetDisabledWrapper, GetBoxDisabled, GetDisabledLabel],
   );
+  const CheckRender = useMemo(
+    () => {
+      if (label && children) {
+        throw new Error("Only Support one, Pick: children as JSX Element or label as string, not both.");
+      }
+      if (children) {
+        return children;
+      }
+      if (label) {
+        return label;
+      }
+      return new Error("Children or Label not Specified");
+     
+    }, [children, label])
   return {
     domRef,
     children,
@@ -155,6 +169,7 @@ export function useCheckbox(props: CheckboxProps) {
     GetCheckboxProps,
     GetBoxStyle,
     label,
+    CheckRender,
     GetSlot,
     className,
     GetWrapperStyle,

--- a/islands/inputs/fieldset/Fieldset.tsx
+++ b/islands/inputs/fieldset/Fieldset.tsx
@@ -35,7 +35,11 @@ import { useFieldset } from "./use-fieldset.ts";
  *   - `"full"`
  * @param {boolean} [isDisabled] - If `true`, the fieldset and its contents will be disabled.
  * @param {string} label - The text content for the Fieldset's label.
- * @param {string} [yuzuDisableStyle] - Custom class name to override the default disabled styles. Use with caution and prefer changing styles via variants.
+ * @param {string} [classNames={{}}] - Custom styles for component
+ * - `yuzuBase`: The base classes applied to the button wrapper.
+ * - `yuzuBaseDisabled`: The base classes applied to the wrapper when disabled
+ * - `yuzuLabel`: The classes applied to the label
+ * - `yuzuLabelDisabled`: The classes applied when the label is disabled.
  */
 const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>((props) => {
   const {

--- a/islands/inputs/fieldset/Fieldset.tsx
+++ b/islands/inputs/fieldset/Fieldset.tsx
@@ -32,8 +32,7 @@ import { useFieldset } from "./use-fieldset.ts";
  *   - and custom color styles.
  * @param {string} [fieldsetVariant="underline"] - The variant style for the fieldset. Possible values include:
  *   - `"underline"`
- *   - `"solid"`
- *   - `"dashed"`
+ *   - `"full"`
  * @param {boolean} [isDisabled] - If `true`, the fieldset and its contents will be disabled.
  * @param {string} label - The text content for the Fieldset's label.
  * @param {string} [yuzuDisableStyle] - Custom class name to override the default disabled styles. Use with caution and prefer changing styles via variants.
@@ -41,13 +40,12 @@ import { useFieldset } from "./use-fieldset.ts";
 const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>((props) => {
   const {
     domRef,
-    style,
     className,
     children,
-    yuzuDisableStyle,
     GetFieldsetClass,
     GetLabelVariant,
     GetFieldsetProps,
+    GetSlot,
     ...otherProps
   } = useFieldset({ ...props });
 
@@ -55,11 +53,10 @@ const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>((props) => {
     <fieldset
       {...otherProps}
       ref={domRef}
-      style={style}
       disabled={GetFieldsetProps.isDisabled}
-      className={`${className} ${GetFieldsetClass.className} ${yuzuDisableStyle}`}
+      className={`${className} ${GetFieldsetClass.className} ${GetSlot.yuzuBase}${GetSlot.yuzuBaseDisabled}`}
     >
-      <legend className={`p-2 m-2 ${GetLabelVariant.labelVariant}`}>
+      <legend className={`p-2 m-2 ${GetLabelVariant.labelVariant} ${GetSlot.yuzuLabel} ${GetSlot.yuzuLabelDisabled}`}>
         {GetLabelVariant.label}
       </legend>
       {children}

--- a/islands/inputs/fieldset/fieldset-variants.ts
+++ b/islands/inputs/fieldset/fieldset-variants.ts
@@ -22,5 +22,5 @@ export const FieldsetVariants = {
     warning: "text-warning",
     none: "",
   },
-  disableStyle: "disabled:opacity-50 ",
+  disableStyle: "disabled:opacity-50 disabled:cursor-not-allowed",
 };

--- a/islands/inputs/fieldset/type.ts
+++ b/islands/inputs/fieldset/type.ts
@@ -3,14 +3,17 @@ import type {
 } from "https://esm.sh/v135/preact@10.22.0/compat/src/index.js";
 import type { JSX } from "preact/jsx-runtime";
 import type { FieldsetVariants } from "./fieldset-variants.ts";
-
+export type FieldsetSlot = Partial<
+  Record<
+    | "yuzuBase"
+    | "yuzuLabel"
+    | "yuzuBaseDisabled"
+    | "yuzuLabelDisabled",
+    string
+  >
+>;
 export type FieldsetProps = JSX.IntrinsicElements["fieldset"] & {
   domRef?: Ref<HTMLFieldSetElement>;
-
-  /**
-   * Css styling
-   */
-  style?: JSX.CSSProperties;
 
   /**
    * Label for the fieldset
@@ -44,11 +47,6 @@ export type FieldsetProps = JSX.IntrinsicElements["fieldset"] & {
   isDisabled?: boolean;
 
   /**
-   * Access to class disabled fieldset
-   */
-  yuzuDisableStyle?: string;
-
-  /**
    * fieldset variant can be extended in variant-file
    * @default underline
    */
@@ -62,7 +60,12 @@ export type FieldsetProps = JSX.IntrinsicElements["fieldset"] & {
   fieldsetColor?: keyof typeof FieldsetVariants.fieldsetColors;
 
   /**
-   * Parent classnames
+   * Parent classnames/ fieldset direct access to classNames
    */
   className?: string;
+
+  /**
+   * Custom Yuzu system for override
+   */
+  classNames?: FieldsetSlot;
 };

--- a/islands/inputs/fieldset/use-fieldset.ts
+++ b/islands/inputs/fieldset/use-fieldset.ts
@@ -102,7 +102,7 @@ export function useFieldset(props: FieldsetProps) {
         yuzuBaseDisabled,
       };
     },
-    [classNames, GetDisabledStyle],
+    [classNames, isDisabled],
   );
   return {
     domRef,

--- a/islands/inputs/fieldset/use-fieldset.ts
+++ b/islands/inputs/fieldset/use-fieldset.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "https://esm.sh/v128/preact@10.22.0/compat/src/index.js";
 import type { FieldsetProps } from "./type.ts";
 import { FieldsetVariants } from "./fieldset-variants.ts";
-import type { JSX } from "preact/jsx-runtime";
+
 
 export function useFieldset(props: FieldsetProps) {
   const {
@@ -14,8 +14,8 @@ export function useFieldset(props: FieldsetProps) {
     fieldsetColor = "primary",
     fieldsetVariant = "underline",
     isDisabled,
+    classNames,
     label,
-    yuzuDisableStyle = "",
     ...otherProps
   } = props;
 
@@ -72,7 +72,12 @@ export function useFieldset(props: FieldsetProps) {
         className: `${color} ${variant} ${direction} ${disabled}`.trim(),
       };
     },
-    [fieldsetDirection, fieldsetColor, fieldsetVariant],
+    [
+      GetFieldsetColor,
+      GetFieldsetVariant,
+      GetFieldsetDirection,
+      GetDisabledStyle,
+    ],
   );
 
   const GetFieldsetProps = useMemo(
@@ -83,6 +88,22 @@ export function useFieldset(props: FieldsetProps) {
     },
     [isDisabled],
   );
+  const GetSlot = useMemo(
+    () => {
+      const yuzuBase = classNames?.yuzuBase ? classNames?.yuzuBase : "";
+      const yuzuLabel = classNames?.yuzuLabel ? classNames?.yuzuLabel : "";
+      const yuzuBaseDisabled = isDisabled ? classNames?.yuzuLabel : "";
+      const yuzuLabelDisabled = isDisabled ? classNames?.yuzuLabelDisabled : "";
+
+      return {
+        yuzuBase,
+        yuzuLabel,
+        yuzuLabelDisabled,
+        yuzuBaseDisabled,
+      };
+    },
+    [classNames, GetDisabledStyle],
+  );
   return {
     domRef,
     style,
@@ -91,8 +112,8 @@ export function useFieldset(props: FieldsetProps) {
     GetFieldsetClass,
     GetLabelVariant,
     GetFieldsetProps,
-    yuzuDisableStyle,
     isDisabled,
+    GetSlot,
     ...otherProps,
   };
 }

--- a/islands/inputs/input/input-variants.ts
+++ b/islands/inputs/input/input-variants.ts
@@ -16,7 +16,8 @@ export const InputVariants = {
     default: "",
   },
 
-  disabledStyle: "opacity-50 cursor-not-allowed",
+  disabledStyle:
+    "opacity-50 cursor-not-allowed disabled:opacity-50 disabled:cursor-not-allowed",
   variants: {
     underline:
       "border-b-2 transition ease-in-out delay-150 duration-300 !rounded-none",
@@ -29,7 +30,8 @@ export const InputVariants = {
   errorStyleParent: "border-error",
   readonlyStyles:
     "opacity-50 read-only:opacity-50 read-only:border-50 read-only:outline-50",
-  inputDisableStyle: "opacity-50 cursor-not-allowed",
+  inputDisableStyle:
+    "opacity-50 cursor-not-allowed disabled:opacity-50 disabled:cursor-not-allowed",
   inputStyle: "w-full border-0 focus:outline-0 focus:ring-0 focus:border-0",
   labelRequiredStyle:
     "after:content-['*'] after:ml-0.5 after:text-red-500 block",

--- a/islands/inputs/label/Labels.tsx
+++ b/islands/inputs/label/Labels.tsx
@@ -29,36 +29,37 @@ import { useLabel } from "./use-label.ts";
  * @param {boolean} [isRequired=false] - Should a label contain asterik for required
  * @param {boolean} [isReadonly=false] - Should a label only read state
  * @param {boolean} [isDisabled=false] - Should a label disabled state
- * @param {string} [yuzuFontReadonly=""] - override styling disabled, better to change in variant file, if no provded will return empty string
- *  * @param {string} [yuzuFontDisabled=""] - override styling disabled, better to change in variant file
- *  * @param {string} [yuzuFontRequired=""] - override styling disabled, better to change in variant file
+ * @param {string} [classNames={{}}] - Custom styles for component
+ * - `yuzuBase`: The base classes applied to the button wrapper.
+ * - `yuzuLabelDisabled`: The base classes applied to the label when disabled
+ * - `yuzuLabelRequired`: The classes applied to the label when required state
+ * - `yuzuLabelReadonly`: The classes applied when the label is readonly.
+ *
  * @return {JSX.Element}
  */
 
 const Label = forwardRef<HTMLLabelElement, LabelProps>((props) => {
   const {
     domRef,
-    label,
     className,
-    children,
-    style,
+    GetSlot,
     GetLabelProps,
-    yuzuFontReadonly,
-    yuzuFontDisabled,
-    yuzuFontRequired,
+    CheckRender,
     ...otherProps
   } = useLabel({ ...props });
 
+  if (CheckRender instanceof Error) {
+    throw CheckRender; 
+  }
+  
   return (
     <label
       {...otherProps}
-      style={style}
       ref={domRef}
       className={`${className} ${GetLabelProps.className}
-      ${yuzuFontDisabled} ${yuzuFontReadonly} ${yuzuFontRequired}`}
+     ${GetSlot.yuzuBase} ${GetSlot.yuzuLabelDisabled} ${GetSlot.yuzuLabelReadonly} ${GetSlot.yuzuLabelRequired}`.trim()}
     >
-      {label}
-      {children}
+      {CheckRender}
     </label>
   );
 });

--- a/islands/inputs/label/label-variant.ts
+++ b/islands/inputs/label/label-variant.ts
@@ -13,11 +13,11 @@ export const LabelVariants = {
     none: "",
   },
   fontWeights: {
-    light: "font light",
+    light: "font-light",
     medium: "font-medium",
     bold: "font-bold",
   },
-  fontReadonly: "read-only:opacity-40 read-only:border-20 read-only:outline-20",
+  fontReadonly: "read-only:opacity-70 read-only:border-20 read-only:outline-20",
   fontRequired: "after:content-['*'] after:ml-0.5 after:text-red-500 block",
-  fontDisabled: "opacity-30",
+  fontDisabled: "opacity-50",
 };

--- a/islands/inputs/label/type.ts
+++ b/islands/inputs/label/type.ts
@@ -3,6 +3,15 @@ import type {
   Ref,
 } from "https://esm.sh/v135/preact@10.22.0/compat/src/index.js";
 import type { LabelVariants } from "./label-variant.ts";
+export type LabelSlot = Partial<
+  Record<
+  |"yuzuBase"
+    | "yuzuLabelRequired"
+    | "yuzuLabelReadonly"
+    | "yuzuLabelDisabled",
+    string
+  >
+>;
 export type LabelProps = JSX.IntrinsicElements["label"] & {
   /**
    * Dom ref
@@ -19,15 +28,12 @@ export type LabelProps = JSX.IntrinsicElements["label"] & {
    */
   className?: string;
 
-  /**
-   * Add children to label
-   */
-  children?: JSX.Element | string;
+  classNames?: LabelSlot
 
   /**
-   * Native style label
-   */
-  style?: JSX.CSSProperties;
+   * Add children to label
+   */ 
+  children?: JSX.Element | string
 
   /**
    * Label size, configuration can be custom to label-variant
@@ -44,20 +50,6 @@ export type LabelProps = JSX.IntrinsicElements["label"] & {
    */
   fontWeight?: keyof typeof LabelVariants.fontWeights;
 
-  /**
-   * Readonly class
-   */
-  yuzuFontReadonly?: string;
-
-  /**
-   * Required class for label
-   */
-  yuzuFontRequired?: string;
-
-  /**
-   * Required class for label
-   */
-  yuzuFontDisabled?: string;
 
   /**
    * the label state readonly

--- a/islands/inputs/label/use-label.ts
+++ b/islands/inputs/label/use-label.ts
@@ -9,15 +9,12 @@ export function useLabel(props: LabelProps) {
     children,
     fontSize = "small",
     fontColor = "none",
-    style = "",
     className = "",
     fontWeight = "medium",
     isDisabled = false,
     isReadonly = false,
     isRequired = false,
-    yuzuFontReadonly = "",
-    yuzuFontDisabled = "",
-    yuzuFontRequired = "",
+    classNames,
     ...otherProps
   } = props;
   const getColors = useMemo(
@@ -38,49 +35,19 @@ export function useLabel(props: LabelProps) {
     },
     [fontWeight],
   );
-  const getReadonly = useMemo(
-    () => {
-      if (isReadonly === true) {
-        const isReadonly = true;
-        const fontReadonly = LabelVariants.fontReadonly;
-        return { isReadonly, fontReadonly };
-      } else if (isDisabled === false) {
-        const isReadonly = false;
-        const fontReadonly = "";
-        return { fontReadonly, isReadonly };
-      }
-    },
-    [isReadonly],
-  );
-  const getRequired = useMemo(
-    () => {
-      if (isRequired === true) {
-        const isRequired = true;
-        const requiredClass = LabelVariants.fontRequired;
-        return { isRequired, requiredClass };
-      } else if (isDisabled === false) {
-        const isRequired = false;
-        const requiredClass = "";
-        return { isRequired, requiredClass };
-      }
-    },
-    [isRequired],
-  );
+  const getReadonly = useMemo(() => {
+    const fontReadonly = isReadonly ? LabelVariants.fontReadonly : "";
+    return { isReadonly, fontReadonly };
+  }, [isReadonly]);
+  const getRequired = useMemo(() => {
+    const requiredClass = isRequired ? LabelVariants.fontRequired : "";
+    return { isRequired, requiredClass };
+  }, [isRequired]);
 
-  const getDisabled = useMemo(
-    () => {
-      if (isDisabled === true) {
-        const isDisabled = true;
-        const disabledClass = LabelVariants.fontDisabled;
-        return { isDisabled, disabledClass };
-      } else if (isDisabled === false) {
-        const isDisabled = false;
-        const disabledClass = "";
-        return { isDisabled, disabledClass };
-      }
-    },
-    [isDisabled],
-  );
+  const getDisabled = useMemo(() => {
+    const disabledClass = isDisabled ? LabelVariants.fontDisabled : "";
+    return { isDisabled, disabledClass };
+  }, [isDisabled]);
 
   const GetLabelProps = useMemo(
     () => {
@@ -99,19 +66,46 @@ export function useLabel(props: LabelProps) {
     [fontColor, fontSize, fontWeight],
   );
 
+  const GetSlot = useMemo(
+    () => {
+      const yuzuBase = classNames?.yuzuBase ? classNames?.yuzuBase : "";
+      const yuzuLabelDisabled = getDisabled.isDisabled ? classNames?.yuzuLabelDisabled  : "";
+      const yuzuLabelReadonly = getReadonly.isReadonly ? classNames?.yuzuLabelReadonly : "";
+      const yuzuLabelRequired = getRequired.isRequired ? classNames?.yuzuLabelRequired : "";
+      return {
+        yuzuBase,
+        yuzuLabelDisabled,
+        yuzuLabelReadonly,
+        yuzuLabelRequired,
+      };
+    },
+    [classNames],
+  );
+  const CheckRender = useMemo(
+    () => {
+      if (label && children) {
+        throw new Error("Only Support one, Pick: children as JSX Element or label as string, not both.");
+      }
+      if (children) {
+        return children;
+      }
+      if (label) {
+        return label;
+      }
+      return new Error("Children or Label not Specified");
+     
+    }, [children, label])
   return {
     domRef,
     label,
     children,
-    style,
     GetLabelProps,
     className,
+    CheckRender,
     isReadonly,
     isRequired,
     isDisabled,
-    yuzuFontReadonly,
-    yuzuFontDisabled,
-    yuzuFontRequired,
+    GetSlot,
     ...otherProps,
   };
 }

--- a/islands/wrapper.tsx
+++ b/islands/wrapper.tsx
@@ -6,6 +6,8 @@ import {
 import Button from "./inputs/button/Button.tsx";
 import Home from "./icon/component/Home.tsx";
 import Checkbox from "./inputs/checkbox/Checkbox.tsx";
+import Fieldset from "./inputs/fieldset/Fieldset.tsx";
+import Input from "./inputs/input/Inputs.tsx";
 
 export default function Wrapper() {
   const fieldsetRef = useRef<HTMLButtonElement>(null);
@@ -29,32 +31,20 @@ export default function Wrapper() {
       <div class={"w-full flex flex-col gap-2"}>
         <div className={""}>
           <div className={`w-full flex flex-col gap-2`}>
-            <Checkbox
+            <Fieldset
+              label={"fruits"}
+              classNames={{
+                yuzuBase: "",
+                yuzuLabel: "bg-blue-500",
+                yuzuBaseDisabled: "bg-blue-500",
+                yuzuLabelDisabled: "font-bold",
+              }}
               isDisabled={false}
-              labelPosition="bottom"
-              name={"data"}
-              id={"name"}
-              label={"did you agree?"}
-              boxSize="small"
-              indeterminate
-              classNames={{
-                yuzuLabelDisabled: "bg-red-500",
-                yuzuInputDisabled: "outline-4 outline-green-300",
-                yuzuBaseDisabled: "ring-4 ring-red-500 bg-red-500",
-                yuzuBase: "bg-blue-100",
-                yuzuInput: "ring ring-red-300",
-                yuzuLabel: "font-bold",
-              }}
-            />
-            <Button
-              isDisabled={true}
-              classNames={{
-                yuzuBase: "bg-red-500",
-                yuzuDisabled: "disabled:ring-2 disabled:ring-yellow-500",
-              }}
+              fieldsetDirection="column"
             >
-              Submit
-            </Button>
+              <Input label={"name"} />
+              <Input label={"name"} />
+            </Fieldset>
           </div>
         </div>
       </div>

--- a/islands/wrapper.tsx
+++ b/islands/wrapper.tsx
@@ -3,11 +3,9 @@ import {
   useRef,
   useState,
 } from "https://esm.sh/v135/preact@10.22.0/compat/src/index.js";
-import Button from "./inputs/button/Button.tsx";
-import Home from "./icon/component/Home.tsx";
+
+import Label from "./inputs/label/Labels.tsx";
 import Checkbox from "./inputs/checkbox/Checkbox.tsx";
-import Fieldset from "./inputs/fieldset/Fieldset.tsx";
-import Input from "./inputs/input/Inputs.tsx";
 
 export default function Wrapper() {
   const fieldsetRef = useRef<HTMLButtonElement>(null);
@@ -31,20 +29,7 @@ export default function Wrapper() {
       <div class={"w-full flex flex-col gap-2"}>
         <div className={""}>
           <div className={`w-full flex flex-col gap-2`}>
-            <Fieldset
-              label={"fruits"}
-              classNames={{
-                yuzuBase: "",
-                yuzuLabel: "bg-blue-500",
-                yuzuBaseDisabled: "bg-blue-500",
-                yuzuLabelDisabled: "font-bold",
-              }}
-              isDisabled={false}
-              fieldsetDirection="column"
-            >
-              <Input label={"name"} />
-              <Input label={"name"} />
-            </Fieldset>
+            <Label>asss</Label>
           </div>
         </div>
       </div>

--- a/task.todo
+++ b/task.todo
@@ -1,6 +1,5 @@
 is it possoble to make selected key disabled from parent?
 
 
-add variant and radius and placement
-
+input not show disabled cursor when disabled when become children
 adding focus on blur and change


### PR DESCRIPTION
### Major Change

**Fieldset Component**
Now add access to native via yuzu system,
```ts
export type FieldsetSlot = Partial<
  Record<
    | "yuzuBase"
    | "yuzuLabel"
    | "yuzuBaseDisabled"
    | "yuzuLabelDisabled",
    string
  >
>;
```

**Label Component**
 Add access to native via yuzu system
```ts
export type LabelSlot = Partial<
  Record<
    | "yuzuBase"
    | "yuzuLabelRequired"
    | "yuzuLabelReadonly"
    | "yuzuLabelDisabled",
    string
  >
>;
```

## Minor Change
Component Checkbox, Label can't render `children && label` together will return error